### PR TITLE
deploy LocalBalzaar API with nginx reverse proxy using Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,16 +1,30 @@
-FROM node:latest
-
-RUN apt update && \
-npm install -g @nestjs/cli
+# Étape 1 : Build de l'application
+FROM node:slim as builder
 
 WORKDIR /app
-EXPOSE 3000
-EXPOSE 8080
 
-COPY *.json ./
-COPY prisma ./
-
+COPY package*.json ./
+COPY prisma/* ./prisma
 RUN npm install
+RUN apt-get update -y && \
+     apt-get install -y openssl &&\
+    npm install -g @nestjs/cli
+
+COPY .env .env
 COPY . .
-VOLUME [ "./:/app" ]
-ENTRYPOINT [ "npm","run","start" ]
+RUN npm run build
+
+# Étape 2 : Image de production
+FROM node:slim
+
+WORKDIR /app
+RUN apt-get update -y && \
+     apt-get install -y openssl &&\
+    npm install -g @nestjs/cli
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/prisma/* ./prisma
+RUN npm install --production
+COPY --from=builder /app/dist ./dist
+
+# Démarre l'application
+CMD ["node", "dist/src/main.js"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,20 +1,25 @@
+version: '3.8'
+
 services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: backend
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"
+      - "8000:8000"
+    restart: unless-stopped
 
-      backend:
-        build: .
-        ports:
-          - "3000:3000"
-          - "8080:8080"
-        develop:
-          watch:
-            - action: sync
-              path: .
-              target: /app
-        networks:
-          - local
-        
-        volumes:
-          - ./:/app
+  nginx:
+    image: nginx:alpine
+    container_name: nginx-proxy
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - backend
 
-networks:
-  local:

--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name localbalzaar.api;
+    location / {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -28,10 +28,12 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
     RolesModule,
     CategoriesModule,
     AuthModule,
-    ConfigModule,
     SendmailModule,
     EventEmitterModule.forRoot({
       wildcard: true,
+    }),
+    ConfigModule.forRoot({
+      isGlobal: true,
     }),
   ],
   controllers: [AppController, AuthController],


### PR DESCRIPTION
🔀 Pull Request: Déploiement initial de l’API localbalzaar avec Nginx
Résumé :

Cette PR met en place le déploiement de l’API localbalzaar via Docker, avec un proxy inverse Nginx configuré pour acheminer les requêtes vers le service localbalzaar .

Modifications principales :

Ajout d’un Dockerfile pour l’API localbalzaar 

Ajout d’un docker-compose.yml avec services nestjs et nginx

Configuration initiale de Nginx (nginx.conf) avec reverse proxy vers nestjs:3000

Résolution de l’erreur host not found in upstream "nestjs" (mauvais nom de service)

Exposition du port 8080 pour accès local via Nginx

Étapes à suivre pour tester :

Lancer docker-compose up --build

Accéder à http://localhost:8080

Vérifier que la route / de l’API localbalzaar répond correctement